### PR TITLE
Enforce OAuth

### DIFF
--- a/internal/context/context.go
+++ b/internal/context/context.go
@@ -52,6 +52,7 @@ type NSSFContext struct {
 	NfService         map[models.ServiceName]models.NfService
 	NrfUri            string
 	SupportedPlmnList []models.PlmnId
+	OAuth             bool `yaml:"OAuth,omitempty"`
 }
 
 // Initialize NSSF context with configuration factory
@@ -90,10 +91,12 @@ func InitNssfContext() {
 	}
 
 	nssfContext.SupportedPlmnList = nssfConfig.Configuration.SupportedPlmnList
+	nssfContext.OAuth = factory.NssfConfig.Configuration.OAuth
 }
 
 func initNfService(serviceName []models.ServiceName, version string) (
-	nfService map[models.ServiceName]models.NfService) {
+	nfService map[models.ServiceName]models.NfService,
+) {
 	versionUri := "v" + strings.Split(version, ".")[0]
 	nfService = make(map[models.ServiceName]models.NfService)
 	for idx, name := range serviceName {

--- a/internal/sbi/consumer/nf_management.go
+++ b/internal/sbi/consumer/nf_management.go
@@ -7,7 +7,6 @@
 package consumer
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"strings"
@@ -37,14 +36,15 @@ func BuildNFProfile(context *nssf_context.NSSFContext) (profile models.NfProfile
 }
 
 func SendRegisterNFInstance(nrfUri, nfInstanceId string, profile models.NfProfile) (
-	resourceNrfUri string, retrieveNfInstanceId string, err error) {
+	resourceNrfUri string, retrieveNfInstanceId string, err error,
+) {
 	configuration := Nnrf_NFManagement.NewConfiguration()
 	configuration.SetBasePath(nrfUri)
 	apiClient := Nnrf_NFManagement.NewAPIClient(configuration)
 
 	var res *http.Response
 	for {
-		_, res, err = apiClient.NFInstanceIDDocumentApi.RegisterNFInstance(context.TODO(), nfInstanceId, profile)
+		_, res, err = apiClient.NFInstanceIDDocumentApi.RegisterNFInstance(openapi.CreateContext(nssf_context.NSSF_Self().OAuth, nssf_context.NSSF_Self().NfId, nssf_context.NSSF_Self().NrfUri, "NSSF"), nfInstanceId, profile)
 		if err != nil || res == nil {
 			// TODO : add log
 			logger.ConsumerLog.Errorf("NSSF register to NRF Error[%s]", err.Error())
@@ -85,7 +85,7 @@ func SendDeregisterNFInstance() (*models.ProblemDetails, error) {
 	var res *http.Response
 	var err error
 
-	res, err = client.NFInstanceIDDocumentApi.DeregisterNFInstance(context.Background(), nssfSelf.NfId)
+	res, err = client.NFInstanceIDDocumentApi.DeregisterNFInstance(openapi.CreateContext(nssf_context.NSSF_Self().OAuth, nssf_context.NSSF_Self().NfId, nssf_context.NSSF_Self().NrfUri, "NSSF"), nssfSelf.NfId)
 	if err == nil {
 		return nil, err
 	} else if res != nil {

--- a/internal/sbi/nssaiavailability/api_nf_instance_id_document.go
+++ b/internal/sbi/nssaiavailability/api_nf_instance_id_document.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 
+	nssf_context "github.com/free5gc/nssf/internal/context"
 	"github.com/free5gc/nssf/internal/logger"
 	"github.com/free5gc/nssf/internal/plugin"
 	"github.com/free5gc/nssf/internal/sbi/producer"
@@ -23,6 +24,12 @@ import (
 )
 
 func HTTPNSSAIAvailabilityDelete(c *gin.Context) {
+	scopes := []string{"nnssf-nssaiavailability"}
+	_, oauth_err := openapi.CheckOAuth(c.Request.Header.Get("Authorization"), scopes)
+	if oauth_err != nil && nssf_context.NSSF_Self().OAuth == true {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": oauth_err.Error()})
+		return
+	}
 	req := httpwrapper.NewRequest(c.Request, nil)
 	req.Params["nfId"] = c.Params.ByName("nfId")
 
@@ -43,6 +50,12 @@ func HTTPNSSAIAvailabilityDelete(c *gin.Context) {
 }
 
 func HTTPNSSAIAvailabilityPatch(c *gin.Context) {
+	scopes := []string{"nnssf-nssaiavailability"}
+	_, oauth_err := openapi.CheckOAuth(c.Request.Header.Get("Authorization"), scopes)
+	if oauth_err != nil && nssf_context.NSSF_Self().OAuth == true {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": oauth_err.Error()})
+		return
+	}
 	var nssaiAvailabilityUpdateInfo plugin.PatchDocument
 
 	requestBody, err := c.GetRawData()
@@ -91,6 +104,12 @@ func HTTPNSSAIAvailabilityPatch(c *gin.Context) {
 }
 
 func HTTPNSSAIAvailabilityPut(c *gin.Context) {
+	scopes := []string{"nnssf-nssaiavailability"}
+	_, oauth_err := openapi.CheckOAuth(c.Request.Header.Get("Authorization"), scopes)
+	if oauth_err != nil && nssf_context.NSSF_Self().OAuth == true {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": oauth_err.Error()})
+		return
+	}
 	var nssaiAvailabilityInfo models.NssaiAvailabilityInfo
 
 	requestBody, err := c.GetRawData()

--- a/internal/sbi/nssaiavailability/api_subscription_id_document.go
+++ b/internal/sbi/nssaiavailability/api_subscription_id_document.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 
+	nssf_context "github.com/free5gc/nssf/internal/context"
 	"github.com/free5gc/nssf/internal/logger"
 	"github.com/free5gc/nssf/internal/sbi/producer"
 	"github.com/free5gc/openapi"
@@ -22,7 +23,14 @@ import (
 )
 
 func HTTPNSSAIAvailabilityUnsubscribe(c *gin.Context) {
-	// Due to conflict of route matching, 'subscriptions' in the route is replaced with the existing wildcard ':nfId'
+	scopes := // Due to conflict of route matching, 'subscriptions' in the route is replaced with the existing wildcard ':nfId'
+		[]string{"nnssf-nssaiavailability"}
+	_, oauth_err := openapi.CheckOAuth(c.Request.Header.Get("Authorization"), scopes)
+	if oauth_err != nil && nssf_context.NSSF_Self().OAuth == true {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": oauth_err.Error()})
+		return
+	}
+
 	nfID := c.Param("nfId")
 	if nfID != "subscriptions" {
 		c.JSON(http.StatusNotFound, gin.H{})

--- a/internal/sbi/nssaiavailability/api_subscriptions_collection.go
+++ b/internal/sbi/nssaiavailability/api_subscriptions_collection.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 
+	nssf_context "github.com/free5gc/nssf/internal/context"
 	"github.com/free5gc/nssf/internal/logger"
 	"github.com/free5gc/nssf/internal/sbi/producer"
 	"github.com/free5gc/openapi"
@@ -22,6 +23,12 @@ import (
 )
 
 func HTTPNSSAIAvailabilityPost(c *gin.Context) {
+	scopes := []string{"nnssf-nssaiavailability"}
+	_, oauth_err := openapi.CheckOAuth(c.Request.Header.Get("Authorization"), scopes)
+	if oauth_err != nil && nssf_context.NSSF_Self().OAuth == true {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": oauth_err.Error()})
+		return
+	}
 	var createData NssfEventSubscriptionCreateData
 
 	requestBody, err := c.GetRawData()

--- a/pkg/factory/config.go
+++ b/pkg/factory/config.go
@@ -43,6 +43,7 @@ type Configuration struct {
 	AmfList                  []AmfConfig             `yaml:"amfList"`
 	TaList                   []TaConfig              `yaml:"taList"`
 	MappingListFromPlmn      []MappingFromPlmnConfig `yaml:"mappingListFromPlmn"`
+	OAuth                    bool                    `yaml:"OAuth,omitempty"`
 }
 
 type Sbi struct {


### PR DESCRIPTION
Hi,

I have modified all Network Functions to properly request and validate OAuth tokens from the NRF's authorization server. This will be part of a larger pull request to free5GC as there are a few repositories to which I need to make pull requests.

This pull request modifies the NSSF to request and validate OAuth tokens sent and received. I added a new configuration variable "OAuth" which determines if OAuth is enforced or not. Please review the changes on this pull request.

NRF Pull Request: https://github.com/free5gc/nrf/pull/8
OpenAPI Pull Request: https://github.com/free5gc/openapi/pull/7

When these three PR's are merged, I will create other pull requests for the rest of the Network Functions. Please let me know if you have further questions.

Thanks!