### PR TITLE
fix: modify resource URI for NSSAIAvailabilityUnsubscribe

### DIFF
--- a/internal/sbi/api_nssaiavailability.go
+++ b/internal/sbi/api_nssaiavailability.go
@@ -65,7 +65,8 @@ func (s *Server) getNssaiAvailabilityRoutes() []Route {
 		{
 			"NSSAIAvailabilityPatchSubscriptions",
 			http.MethodPatch,
-			"/nssai-availability/subscriptions/:subscriptionId",
+			// "/nssai-availability/subscriptions/:subscriptionId",
+			"/nssai-availability/:nfId/:subscriptionId",
 			s.NSSAIAvailabilitySubscriptionPatch,
 		},
 
@@ -196,6 +197,25 @@ func (s *Server) NSSAIAvailabilityPut(c *gin.Context) {
 }
 
 func (s *Server) NSSAIAvailabilitySubscriptionPatch(c *gin.Context) {
+	// Due to conflict of route matching, 'subscriptions' in the route is replaced with the existing wildcard ':nfId'
+	nfID := c.Param("nfId")
+	if nfID != "subscriptions" {
+		c.JSON(http.StatusNotFound, gin.H{})
+		logger.NssaiavailLog.Infof("404 Not Found")
+		return
+	}
+
+	subscriptionId := c.Params.ByName("subscriptionId")
+	if subscriptionId == "" {
+		problemDetails := &models.ProblemDetails{
+			Status: http.StatusBadRequest,
+			Cause:  "UNSPECIFIED", // TODO: Check if this is the correct cause
+		}
+
+		util.GinProblemJson(c, problemDetails)
+		return
+	}
+
 	c.Status(http.StatusNotImplemented)
 }
 

--- a/internal/sbi/api_nssaiavailability.go
+++ b/internal/sbi/api_nssaiavailability.go
@@ -44,14 +44,10 @@ func (s *Server) getNssaiAvailabilityRoutes() []Route {
 			s.NSSAIAvailabilityPut,
 		},
 
-		// Regular expressions for route matching should be unique in Gin package
-		// 'subscriptions' would conflict with existing wildcard ':nfId'
-		// Simply replace 'subscriptions' with ':nfId' and check if ':nfId' is 'subscriptions' in handler function
 		{
 			"NSSAIAvailabilityUnsubscribe",
 			http.MethodDelete,
-			// "/nssai-availability/subscriptions/:subscriptionId",
-			"/nssai-availability/:nfId/:subscriptionId",
+			"/nssai-availability/subscriptions/:subscriptionId",
 			s.NSSAIAvailabilityUnsubscribeDelete,
 		},
 
@@ -65,8 +61,7 @@ func (s *Server) getNssaiAvailabilityRoutes() []Route {
 		{
 			"NSSAIAvailabilityPatchSubscriptions",
 			http.MethodPatch,
-			// "/nssai-availability/subscriptions/:subscriptionId",
-			"/nssai-availability/:nfId/:subscriptionId",
+			"/nssai-availability/subscriptions/:subscriptionId",
 			s.NSSAIAvailabilitySubscriptionPatch,
 		},
 
@@ -197,25 +192,6 @@ func (s *Server) NSSAIAvailabilityPut(c *gin.Context) {
 }
 
 func (s *Server) NSSAIAvailabilitySubscriptionPatch(c *gin.Context) {
-	// Due to conflict of route matching, 'subscriptions' in the route is replaced with the existing wildcard ':nfId'
-	nfID := c.Param("nfId")
-	if nfID != "subscriptions" {
-		c.JSON(http.StatusNotFound, gin.H{})
-		logger.NssaiavailLog.Infof("404 Not Found")
-		return
-	}
-
-	subscriptionId := c.Params.ByName("subscriptionId")
-	if subscriptionId == "" {
-		problemDetails := &models.ProblemDetails{
-			Status: http.StatusBadRequest,
-			Cause:  "UNSPECIFIED", // TODO: Check if this is the correct cause
-		}
-
-		util.GinProblemJson(c, problemDetails)
-		return
-	}
-
 	c.Status(http.StatusNotImplemented)
 }
 
@@ -258,14 +234,6 @@ func (s *Server) NSSAIAvailabilityOptions(c *gin.Context) {
 }
 
 func (s *Server) NSSAIAvailabilityUnsubscribeDelete(c *gin.Context) {
-	// Due to conflict of route matching, 'subscriptions' in the route is replaced with the existing wildcard ':nfId'
-	nfID := c.Param("nfId")
-	if nfID != "subscriptions" {
-		c.JSON(http.StatusNotFound, gin.H{})
-		logger.NssaiavailLog.Infof("404 Not Found")
-		return
-	}
-
 	subscriptionId := c.Params.ByName("subscriptionId")
 	if subscriptionId == "" {
 		problemDetails := &models.ProblemDetails{


### PR DESCRIPTION
After testing, there's no conflict between 'subscriptions' and ':nfId'. Therefore, I modified the resource URI for NSSAIAvailabilityUnsubscribe to '/nssai-availability/subscriptions/:subscriptionId', which aligns with the definition in the specification.

The resource URI is specified in TS 29.531.
![image](https://github.com/user-attachments/assets/935ec87f-d4df-4b2a-a06a-81070d83dad3)
