### PR TITLE
fix: handle nil expiry in NSSAIAvailability POST api request

### DIFF
--- a/internal/sbi/processor/nssaiavailability_subscription.go
+++ b/internal/sbi/processor/nssaiavailability_subscription.go
@@ -77,7 +77,7 @@ func (p *Processor) NssaiAvailabilitySubscriptionCreate(
 	factory.NssfConfig.Subscriptions = append(factory.NssfConfig.Subscriptions, subscription)
 
 	response.SubscriptionId = subscription.SubscriptionId
-	if !subscription.SubscriptionData.Expiry.IsZero() {
+	if subscription.SubscriptionData.Expiry != nil && !subscription.SubscriptionData.Expiry.IsZero() {
 		response.Expiry = new(time.Time)
 		*response.Expiry = *subscription.SubscriptionData.Expiry
 	}


### PR DESCRIPTION
This PR is related to issue [#704](https://github.com/free5gc/free5gc/issues/704).
According to TS 29.531, the expiry field is optional. Therefore, a nil check is required before dereferencing it.