### PR TITLE
fix: return 400 Bad Request when mandatory IE is missing in NssaiAvailabilityInfo

### DIFF
--- a/internal/sbi/processor/nssaiavailability_store.go
+++ b/internal/sbi/processor/nssaiavailability_store.go
@@ -174,6 +174,17 @@ func (p *Processor) NssaiAvailabilityNfInstanceUpdate(
 	)
 
 	for _, s := range nssaiAvailabilityInfo.SupportedNssaiAvailabilityData {
+		if s.Tai == nil || s.Tai.PlmnId == nil {
+			problemDetails = &models.ProblemDetails{
+				Title:  util.MANDATORY_IE_MISSING,
+				Status: http.StatusBadRequest,
+				Detail: "tai or tai.plmnId is missing in supportedNssaiAvailabilityData",
+			}
+			c.Set(sbi.IN_PB_DETAILS_CTX_STR, problemDetails.Title)
+			util.GinProblemJson(c, problemDetails)
+			return
+		}
+
 		if !util.CheckSupportedNssaiInPlmn(s.SupportedSnssaiList, *s.Tai.PlmnId) {
 			problemDetails = &models.ProblemDetails{
 				Title:  util.UNSUPPORTED_RESOURCE,


### PR DESCRIPTION
## Note
- This fix adds a check to see whether s.Tai or s.Tai.PlmnId is nil for nssaiAvailabilityInfo.
- This is reported in [GitHub Issue #911](https://github.com/free5gc/free5gc/issues/911).