### PR TITLE
fix(nssf): validate nsselection slice info inputs

### DIFF
--- a/internal/sbi/processor/nsselection_network_slice_information.go
+++ b/internal/sbi/processor/nsselection_network_slice_information.go
@@ -104,9 +104,24 @@ func (p *Processor) NSSelectionSliceInformationGet(
 	if param.SliceInfoRequestForRegistration != nil {
 		// Network slice information is requested during the Registration procedure
 		status, response, problemDetails = nsselectionForRegistration(param)
-	} else {
+	} else if param.SliceInfoRequestForPduSession != nil {
 		// Network slice information is requested during the PDU session establishment procedure
 		status, response, problemDetails = nsselectionForPduSession(param)
+	} else {
+		problemDetails = &models.ProblemDetails{
+			Title:  util.MANDATORY_IE_MISSING,
+			Status: http.StatusBadRequest,
+			Cause:  "MANDATORY_IE_MISSING",
+			Detail: "Either `slice-info-request-for-registration` or `slice-info-request-for-pdu-session` should be provided",
+			InvalidParams: []models.InvalidParam{
+				{
+					Param: "slice-info-request-for-registration",
+				},
+				{
+					Param: "slice-info-request-for-pdu-session",
+				},
+			},
+		}
 	}
 
 	// TODO: Handle `SliceInfoRequestForUeConfigurationUpdate`
@@ -567,6 +582,23 @@ func nsselectionForPduSession(param NetworkSliceInformationGetQuery) (
 ) {
 	var status int
 	authorizedNetworkSliceInfo := &models.AuthorizedNetworkSliceInfo{}
+
+	if param.SliceInfoRequestForPduSession.SNssai == nil {
+		problemDetails := &models.ProblemDetails{
+			Title:  util.MANDATORY_IE_MISSING,
+			Status: http.StatusBadRequest,
+			Cause:  "MANDATORY_IE_MISSING",
+			Detail: "[Query Parameter] `slice-info-request-for-pdu-session.s-nssai` is required",
+			InvalidParams: []models.InvalidParam{
+				{
+					Param: "slice-info-request-for-pdu-session.s-nssai",
+				},
+			},
+		}
+
+		status = http.StatusBadRequest
+		return status, nil, problemDetails
+	}
 
 	if param.HomePlmnId != nil {
 		// Check whether UE's Home PLMN is supported when UE is a roamer


### PR DESCRIPTION
### **fix(nssf): validate NSSelection PDU request to prevent nil panic (#914)**

- This PR fixes issue #914 in NSSF NSSelection GET network-slice-information.
   It also fixes issue #912 and issue #913 for the similar problem.

- Root cause: the PDU-session path could dereference a nil sNssai and trigger panic/500.

- Changes: Validate that at least one slice-info request (registration or pdu-session) is present.
  In nsselectionForPduSession, reject missing/null sNssai with 400 Bad Request.
  Return MANDATORY_IE_MISSING with clear invalid parameter details.

- This is reported in [GitHub Issue #912](https://github.com/free5gc/free5gc/issues/912), [GitHub Issue #913](https://github.com/free5gc/free5gc/issues/913), [GitHub Issue #914](https://github.com/free5gc/free5gc/issues/914).