### PR TITLE
fix: config validation error handling

### DIFF
--- a/pkg/factory/config.go
+++ b/pkg/factory/config.go
@@ -117,7 +117,7 @@ func (c *Configuration) validate() (bool, error) {
 		case "nnssf-nssaiavailability":
 		default:
 			err := errors.New("Invalid serviceNameList[" + strconv.Itoa(index) + "]: " +
-				string(serviceName) + ", should be nausf-auth.")
+				string(serviceName) + ", should be nnssf-nsselection or nnssf-nssaiavailability.")
 			return false, err
 		}
 	}

--- a/pkg/factory/factory.go
+++ b/pkg/factory/factory.go
@@ -41,9 +41,12 @@ func ReadConfig(cfgPath string) (*Config, error) {
 		return nil, fmt.Errorf("ReadConfig [%s] Error: %+v", cfgPath, err)
 	}
 	if _, err := cfg.Validate(); err != nil {
-		validErrs := err.(govalidator.Errors).Errors()
-		for _, validErr := range validErrs {
-			logger.CfgLog.Errorf("%+v", validErr)
+		if validErrs, ok := err.(govalidator.Errors); ok {
+			for _, validErr := range validErrs.Errors() {
+				logger.CfgLog.Errorf("%+v", validErr)
+			}
+		} else {
+			logger.CfgLog.Errorf("%+v", err)
 		}
 		logger.CfgLog.Errorf("[-- PLEASE REFER TO SAMPLE CONFIG FILE COMMENTS --]")
 		return nil, fmt.Errorf("Config validate Error")


### PR DESCRIPTION

- Prevent a panic when configuration validation returns an error other than `govalidator.Errors`.
- Log non-`govalidator` validation errors directly.
- Correct the validation message for supported NSSF service names.
- This is reported in [GitHub Issue #1106](https://github.com/free5gc/free5gc/issues/1106).
